### PR TITLE
Bug - management of all os indicated in the defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ None.
 
     - hosts: servers
       roles:
-        - plasticrake.ookla-speedtest
+        - ansible-role-ookla-speedtest
       become: yes
 
 ## License

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
   when: speedtest_remove_conflicts|bool
 
 - include_tasks: Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: (ansible_os_family == 'Debian') or (ansible_os_family == 'Ubuntu')
 
 - include_tasks: RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: (ansible_os_family == 'RedHat') or (ansible_os_family == 'CentOS') or (ansible_os_family == 'Fedora')


### PR DESCRIPTION
Management of all os indicated in the defaults ansible vars
FIX: https://github.com/plasticrake/ansible-role-ookla-speedtest/issues/3